### PR TITLE
remove get prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ get_customer_record()
 
 **Good:**
 ```ruby
-get_user()
+user()
 ```
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Ruby convention not use get/set prefix