### PR TITLE
Fix the Bad example code for Open/Closed Principle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,11 +1131,10 @@ class HttpRequester
   end
 
   def fetch(url)
-    adapter_name = @adapter.name
-
-    if adapter_name == 'ajaxAdapter'
+    case @adapter.name
+    when 'ajaxAdapter'
       make_ajax_call(url)
-    elsif adapter_name == 'nodeAdapter'
+    when 'nodeAdapter'
       make_http_call(url)
     end
   end

--- a/README.md
+++ b/README.md
@@ -1135,7 +1135,7 @@ class HttpRequester
 
     if adapter_name == 'ajaxAdapter'
       make_ajax_call(url)
-    elsif adapter_name == 'httpNodeAdapter'
+    elsif adapter_name == 'nodeAdapter'
       make_http_call(url)
     end
   end

--- a/translations/pt-BR.md
+++ b/translations/pt-BR.md
@@ -1147,11 +1147,10 @@ class HttpRequester
   end
 
   def fetch(url)
-    adapter_name = @adapter.name
-
-    if adapter_name == 'ajaxAdapter'
+    case @adapter.name
+    when 'ajaxAdapter'
       make_ajax_call(url)
-    elsif adapter_name == 'nodeAdapter'
+    when 'nodeAdapter'
       make_http_call(url)
     end
   end

--- a/translations/pt-BR.md
+++ b/translations/pt-BR.md
@@ -1151,7 +1151,7 @@ class HttpRequester
 
     if adapter_name == 'ajaxAdapter'
       make_ajax_call(url)
-    elsif adapter_name == 'httpNodeAdapter'
+    elsif adapter_name == 'nodeAdapter'
       make_http_call(url)
     end
   end


### PR DESCRIPTION
The String `'httpNodeAdapter'` was erroneously used.
It should be `'nodeAdapter'`

- 8686e5c replaces an `if` statement with a `case`, eliminating the need for the local variable `adapter_type` and shortening the whole example.
- usually in Ruby code magic Symbols are used instead of magic Strings, e.g. `:ajaxAdapter`, but this is a contrived example anyway, so I left the Strings as they were.