### PR TITLE
Use two arguments in function arguments example

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,23 +233,18 @@ properties are being used.
 
 **Bad:**
 ```ruby
-def create_menu(title, body, button_text, cancellable)
+def create_menu(title, body)
   # ...
 end
 ```
 
 **Good:**
 ```ruby
-def create_menu(title:, body:, button_text:, cancellable:)
+def create_menu(title:, body:)
   # ...
 end
 
-create_menu(
-  title: 'Foo',
-  body: 'Bar',
-  button_text: 'Baz',
-  cancellable: true
-)
+create_menu(title: 'Foo', body: 'Bar')
 ```
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
This resolves https://github.com/uohzxela/clean-code-ruby/issues/24 which is to give an example that only uses two arguments in a function/method to remain consistent with previous advice in the README.

#### Preview:

![changes](https://user-images.githubusercontent.com/6234571/50531252-c910e300-0abb-11e9-9be3-309e8651be00.png)
