### PR TITLE
Add a short description under "Function names should say what they do"

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ email_clients(active_clients(clients))
 **[⬆ back to top](#table-of-contents)**
 
 ### Function names should say what they do
+Poorly named methods add to the code reviewer's cognitive load at best, and mislead the
+code reviewer at worst. Strive to capture the the precise intent when naming methods.
 
 **Bad:**
 ```ruby


### PR DESCRIPTION
This resolves https://github.com/uohzxela/clean-code-ruby/issues/25 which adds a short description as seen in the screen grab to the section on function/method names.

#### Preview:

![names](https://user-images.githubusercontent.com/6234571/50531366-5b65b680-0abd-11e9-8072-e789696a20aa.png)
