### PR TITLE
Use symbols instead of strings to identify employee type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1667,11 +1667,11 @@ class PerformanceReview
   end
 
   def lookup_peers
-    db.lookup(@employee, 'peers')
+    db.lookup(@employee, :peers)
   end
 
   def lookup_manager
-    db.lookup(@employee, 'manager')
+    db.lookup(@employee, :manager)
   end
 
   def peer_reviews
@@ -1718,7 +1718,7 @@ class PerformanceReview
   end
 
   def lookup_peers
-    db.lookup(@employee, 'peers')
+    db.lookup(@employee, :peers)
   end
 
   def manager_review
@@ -1727,7 +1727,7 @@ class PerformanceReview
   end
 
   def lookup_manager
-    db.lookup(@employee, 'manager')
+    db.lookup(@employee, :manager)
   end
 
   def self_review


### PR DESCRIPTION
Symbols are compared faster than strings, so it's more idiomatic to use them here. 