### PR TITLE
Correct links for attributes blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,7 +889,7 @@ toy.price = 50
 toy.price # => 50
 ```
 
-However, you have to be aware that in some situations, using `attr_accessor` is a code smell, read more [here](http://solnic.eu/2012/04/04/get-rid-of-that-code-smell-attributes.html).
+However, you have to be aware that in some situations, using `attr_accessor` is a code smell, read more [here](https://solnic.codes/2012/04/04/get-rid-of-that-code-smell-attributes).
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/translations/pt-BR.md
+++ b/translations/pt-BR.md
@@ -902,7 +902,7 @@ toy.price # => 50
 ```
 Contudo, você precisa estar ciente de que em algumas situações, usar
 `attr_accessor` é um *code smell*, leia mais sobre
-[aqui](http://solnic.eu/2012/04/04/get-rid-of-that-code-smell-attributes.html).
+[aqui](https://solnic.codes/2012/04/04/get-rid-of-that-code-smell-attributes).
 
 **[⬆ retornar ao topo](#sumário)**
 

--- a/translations/zh-CN.md
+++ b/translations/zh-CN.md
@@ -21,7 +21,7 @@
 
 
 
-## 介绍 
+## 介绍
 
 软件工程的原则，来自于Robert C. Martin的书[*Clean Code*](https://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882),
 应用于Ruby。这不是样式指南。它是构建[可读，可复用，可重构](https://github.com/ryanmcdermott/3rs-of-software-architecture) 工业级的Ruby软件工程指南。
@@ -828,7 +828,7 @@ toy.price = 50
 toy.price # => 50
 ```
 
-然而，你必须意识到在有些情况，使用`attr_accessor`也是臭代码，你可以看看[这里](http://solnic.eu/2012/04/04/get-rid-of-that-code-smell-attributes.html)
+然而，你必须意识到在有些情况，使用`attr_accessor`也是臭代码，你可以看看[这里](https://solnic.codes/2012/04/04/get-rid-of-that-code-smell-attributes)
 **[⬆ 回到目录](#目录)**
 
 


### PR DESCRIPTION
The current link for [Objects and Data Structures](https://github.com/uohzxela/clean-code-ruby/tree/e6b117f8bce146d070c22b659f8bc6a2c83559ce#objects-and-data-structures) 
leads to an inappropriate website, the new link is adjusted
with the correct domain extension (.eu -> .codes) 
which leads to the [actual blog article](https://solnic.codes/2012/04/04/get-rid-of-that-code-smell-attributes/).

Addresses https://github.com/uohzxela/clean-code-ruby/issues/40